### PR TITLE
Add basic BLE iOS example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/HugoBlinkyApp/BLEManager.swift
+++ b/HugoBlinkyApp/BLEManager.swift
@@ -1,0 +1,68 @@
+import Foundation
+import CoreBluetooth
+
+class BLEManager: NSObject, ObservableObject {
+    private var centralManager: CBCentralManager!
+    private var ledCharacteristic: CBCharacteristic?
+
+    @Published var isConnected = false
+    @Published var ledOn = false
+
+    private let deviceName = "Hugo_Blinky"
+    private let ledServiceUUID = CBUUID(string: "FFE0")
+    private let ledCharacteristicUUID = CBUUID(string: "FFE1")
+
+    override init() {
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    func startScanning() {
+        centralManager.scanForPeripherals(withServices: nil, options: nil)
+    }
+
+    func toggleLED() {
+        guard let characteristic = ledCharacteristic else { return }
+        ledOn.toggle()
+        let value: UInt8 = ledOn ? 1 : 0
+        let data = Data([value])
+        centralManager.writeValue(data, for: characteristic, type: .withoutResponse)
+    }
+}
+
+extension BLEManager: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state == .poweredOn {
+            central.scanForPeripherals(withServices: nil, options: nil)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
+        if peripheral.name == deviceName {
+            central.stopScan()
+            peripheral.delegate = self
+            central.connect(peripheral, options: nil)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        isConnected = true
+        peripheral.discoverServices([ledServiceUUID])
+    }
+}
+
+extension BLEManager: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard let services = peripheral.services else { return }
+        for service in services where service.uuid == ledServiceUUID {
+            peripheral.discoverCharacteristics([ledCharacteristicUUID], for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        guard let characteristics = service.characteristics else { return }
+        for characteristic in characteristics where characteristic.uuid == ledCharacteristicUUID {
+            ledCharacteristic = characteristic
+        }
+    }
+}

--- a/HugoBlinkyApp/ContentView.swift
+++ b/HugoBlinkyApp/ContentView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var bleManager: BLEManager
+
+    var body: some View {
+        VStack {
+            Text(bleManager.isConnected ? "Connected" : "Disconnected")
+                .padding()
+            Button(action: {
+                bleManager.toggleLED()
+            }) {
+                Text(bleManager.ledOn ? "Turn Off" : "Turn On")
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+            .disabled(!bleManager.isConnected)
+        }
+        .onAppear {
+            bleManager.startScanning()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(BLEManager())
+    }
+}

--- a/HugoBlinkyApp/HugoBlinkyApp.swift
+++ b/HugoBlinkyApp/HugoBlinkyApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import CoreBluetooth
+
+@main
+struct HugoBlinkyApp: App {
+    @StateObject private var bleManager = BLEManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(bleManager)
+        }
+    }
+}

--- a/HugoBlinkyApp/Info.plist
+++ b/HugoBlinkyApp/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>HugoBlinkyApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.HugoBlinkyApp</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>This app uses Bluetooth to control the LED.</string>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "HugoBlinkyApp",
+    platforms: [.iOS(.v14)],
+    products: [
+        .library(name: "HugoBlinkyApp", targets: ["HugoBlinkyApp"]),
+    ],
+    targets: [
+        .target(name: "HugoBlinkyApp", path: "HugoBlinkyApp"),
+    ]
+)

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,11 @@
-init the project``
+# HugoBlinky iOS Example
+
+This sample project shows how to connect to an nRF52830 BLE device named **Hugo_Blinky** and control its LED. The app scans for the device, connects automatically, and provides a button to toggle the LED on and off.
+
+## Running the App
+1. Open Xcode on macOS and create a new **App** project using SwiftUI.
+2. Replace the generated source files with the contents of the `HugoBlinkyApp` folder in this repository.
+3. Add `Info.plist` from `HugoBlinkyApp` to your Xcode project and ensure it contains the Bluetooth usage description.
+4. Build and run on a real iOS device (e.g., iPhone 16 Pro). The app will start scanning as soon as it launches.
+
+The BLE service and characteristic UUIDs are set to `FFE0` and `FFE1`. Update them if your device uses different values.


### PR DESCRIPTION
## Summary
- implement simple SwiftUI app to connect to `Hugo_Blinky`
- provide BLE manager for toggling LED via FFE0/FFE1 characteristics
- add info plist and usage description
- document how to use the code with Xcode

## Testing
- `swift build` *(fails: no such module 'CoreBluetooth')*

------
https://chatgpt.com/codex/tasks/task_e_68444d4c92e8832e8b95ef7387645e6a